### PR TITLE
QtkIOSystem improvements

### DIFF
--- a/src/qtk/qtkiostream.cpp
+++ b/src/qtk/qtkiostream.cpp
@@ -18,20 +18,21 @@ QtkIOStream::QtkIOStream(const char * pFile, const char * pMode) :
     mFile(pFile) {
   QString mode(pMode);
   bool open = false;
-  if (mode == "w" || mode == "wb") {
+  if(mode == "w" || mode == "wb") {
     open = mFile.open(QIODeviceBase::WriteOnly);
-  } else if (mode == "r" || mode == "rb") {
+  } else if(mode == "r" || mode == "rb") {
     open = mFile.open(QIODeviceBase::ReadOnly);
-  } else if (mode == "wt") {
+  } else if(mode == "wt") {
     open = mFile.open(QIODeviceBase::WriteOnly | QIODeviceBase::Text);
-  } else if (mode == "rt") {
+  } else if(mode == "rt") {
     open = mFile.open(QIODeviceBase::ReadOnly | QIODeviceBase::Text);
   } else {
     open = false;
     qDebug() << "[Qtk::QtkIOStream] Invalid file open mode: " << mode << "\n";
   }
   if(!open) {
-    qDebug() << "[Qtk::QtkIOStream] Could not open file: " << QString(pFile) << "\n";
+    qDebug() << "[Qtk::QtkIOStream] Could not open file: " << QString(pFile)
+             << "\n";
   }
 }
 
@@ -40,7 +41,7 @@ QtkIOStream::QtkIOStream(const char * pFile, const char * pMode) :
  ******************************************************************************/
 
 size_t QtkIOStream::Read(void * pvBuffer, size_t pSize, size_t pCount) {
-  qint64 readSize = mFile.read((char*)pvBuffer, pSize * pCount);
+  qint64 readSize = mFile.read((char *)pvBuffer, pSize * pCount);
   if(readSize < 0) {
     qDebug() << "[Qtk::QtkIOStream] Failed to read (" << pSize
              << ") bytes from file at: " << mFile.filesystemFileName().c_str()
@@ -51,12 +52,10 @@ size_t QtkIOStream::Read(void * pvBuffer, size_t pSize, size_t pCount) {
 }
 
 size_t QtkIOStream::Write(const void * pvBuffer, size_t pSize, size_t pCount) {
-  qint64 writeSize = mFile.write((char*)pvBuffer, pSize * pCount);
+  qint64 writeSize = mFile.write((char *)pvBuffer, pSize * pCount);
   if(writeSize < 0) {
-    qDebug() << "[Qtk::QtkIOStream] Failed to write buffer with size ("
-             << pSize
-             << ") to file at: " << mFile.filesystemFileName().c_str()
-             << "\n";
+    qDebug() << "[Qtk::QtkIOStream] Failed to write buffer with size (" << pSize
+             << ") to file at: " << mFile.filesystemFileName().c_str() << "\n";
     return -1;
   }
   return writeSize;

--- a/src/qtk/qtkiosystem.cpp
+++ b/src/qtk/qtkiosystem.cpp
@@ -7,6 +7,7 @@
 ##############################################################################*/
 
 #include "qtkiosystem.h"
+#include <QDir>
 
 using namespace Qtk;
 
@@ -19,15 +20,11 @@ bool QtkIOSystem::Exists(const char * pFile) const {
 }
 
 char QtkIOSystem::getOsSeparator() const {
-#ifndef _WIN32
-  return '/';
-#else
-  return '\\';
-#endif
+  return QDir::separator().toLatin1();
 }
 
 Assimp::IOStream * QtkIOSystem::Open(const char * pFile, const char * pMode) {
-  if(!QFileInfo::exists(pFile)) {
+  if(!Exists(pFile)) {
     qDebug() << "[Qtk::QtkIOSystem] failed to open file: " << pFile << "\n";
     return nullptr;
   }


### PR DESCRIPTION
**`QtIOSystem::getOsSeparator()`**
I use the function `QDir::separator()` instead of macros, because Qt will use the correct character for internal processing in any case.

**`QtkIOSystem::Open`**
At this point I use `QtkIOSystem::Exists` so that only one implementation of the check function is necessary. `QFileInfo::exists` works, but the function also returns `true` if the specified path is a directory and not a file. If you add the check whether it is also a file, you do not have to do this twice.

**`QtkIOStream::QtkIOStream`**
The file `IOSystem.hpp` states that the modes `wb`, `w`, `wt`, `rb`, `r` and `rt` must be handled. The `t` stands for text and is a corresponding parameter that must not be omitted.

**`QtkIOStream::Read` and `QtkIOStream::Write`**
Loops are not necessary at these points. The pointers and size information can be passed directly to the corresponding Qt objects.